### PR TITLE
Imp/statistics

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,8 @@ from starlette.responses import JSONResponse, RedirectResponse
 
 from db.create_database import create_tables
 from db.database import SessionLocal
-from routers import product, category, insert_data, auth, ratingUser, review, user, ratingProduct, wishlist, orders
+from routers import (product, category, insert_data, auth, ratingUser, review, user, ratingProduct, wishlist, orders,
+                     statistics)
 
 
 @asynccontextmanager
@@ -117,6 +118,7 @@ app.include_router(router=ratingProduct.router)
 app.include_router(router=ratingUser.router)
 app.include_router(router=wishlist.router)
 app.include_router(router=orders.router)
+app.include_router(router=statistics.router)
 
 load_dotenv(".aws")
 s3 = boto3.client(

--- a/models/orders/order.py
+++ b/models/orders/order.py
@@ -40,6 +40,9 @@ class Order(Base):
             "status": self.status,
             "order_items": [item.to_dict(db=db) for item in get_order_items_by_order_id(self.id, db)]
         }
+    
+    def get_order_items(self, db: Session = Depends(get_db)):
+        return [item.to_dict(db=db) for item in get_order_items_by_order_id(self.id, db)]
 
     def add_order_item(self, order_item, db: Session = Depends(get_db)):
         self.order_items.append(order_item)

--- a/models/user.py
+++ b/models/user.py
@@ -117,11 +117,10 @@ class User(Base):
         db.refresh(self)
         return self
 
-    def update_views(self, db: Session = Depends(get_db)):
+    def add_views(self, db: Session = Depends(get_db)):
         self.views += 1
         db.commit()
         db.refresh(self)
-        return self
 
 
 def save_user(new_user: CreateUser, db: Session = Depends(get_db)):

--- a/models/user.py
+++ b/models/user.py
@@ -34,6 +34,7 @@ class User(Base):
     city = Column(String(200), index=True, nullable=False)
     region = Column(String(200), index=True, nullable=False)
     photo = Column(String(200), index=True, nullable=False)
+    views = Column(Integer, index=True, default=0)
     role = Column(Enum(Role), index=True, nullable=False, default="Client")
     avg_rating = Column(Float, index=True, default=0)
     created_at = Column(DateTime(timezone=True), index=True, default=datetime.datetime.now(), nullable=False)
@@ -112,6 +113,12 @@ class User(Base):
     
     def update_role(self, role: str, db: Session = Depends(get_db)):
         self.role = role
+        db.commit()
+        db.refresh(self)
+        return self
+
+    def update_views(self, db: Session = Depends(get_db)):
+        self.views += 1
         db.commit()
         db.refresh(self)
         return self

--- a/repositories/orderItemRepo.py
+++ b/repositories/orderItemRepo.py
@@ -10,8 +10,4 @@ def get_order_items_by_order_id(id_order: str, db: Session = Depends(get_db)):
 
 
 def get_orders_items_by_product_id(id_product: str, db: Session = Depends(get_db)):
-<<<<<<< HEAD
     return db.query(OrderItem).filter(OrderItem.product_id == id_product).all()
-=======
-    return db.query(OrderItem).filter(OrderItem.product_id == id_product).all()
->>>>>>> imp/MM-38-product-available

--- a/repositories/orderItemRepo.py
+++ b/repositories/orderItemRepo.py
@@ -7,3 +7,7 @@ from models.orders.order_item import OrderItem
 
 def get_order_items_by_order_id(id_order: str, db: Session = Depends(get_db)):
     return db.query(OrderItem).filter(OrderItem.order_id == id_order).all()
+
+
+def get_orders_items_by_product_id(id_product: str, db: Session = Depends(get_db)):
+    return db.query(OrderItem).filter(OrderItem.product_id == id_product).all()

--- a/routers/statistics.py
+++ b/routers/statistics.py
@@ -34,14 +34,14 @@ async def statistics(db: Session = Depends(get_db), username: str = Depends(get_
             total_quantity += item.quantity
 
         total_views_products += get_product_by_id(product_id, db).views
-    total_views_profile = 0  # TODO: IMPLEMENTAR
+    total_views_profile = user.views
     top_product_sale = max(sales, key=lambda k: sales[k])
 
     response = {"chart": sales,
                 "statistics":
                     {
                         "total quantity": total_quantity, "total views profile": total_views_profile,
-                        "total views Products": total_views_products, "top product sale": products_names[0]
+                        "total views Products": total_views_products, "top product sale": top_product_sale
                     }
                 }
     return JSONResponse(status_code=200, content=jsonable_encoder(response))

--- a/routers/statistics.py
+++ b/routers/statistics.py
@@ -22,18 +22,17 @@ async def statistics(db: Session = Depends(get_db), username: str = Depends(get_
         Function that returns the statistics of the seller
     """
     user = get_user(username, db)
-    products_names = [product.name for product in get_products_by_user_id(user.id, db)]
+    products_id = [product.id for product in get_products_by_user_id(user.id, db)]
     sales = {}
     total_quantity = 0
     total_views_products = 0
-    for product_id in products_names:
+    for product_id in products_id:
         sales[product_id] = 0
         items = get_orders_items_by_product_id(product_id, db)
         for item in items:
             sales[product_id] += item.quantity
             total_quantity += item.quantity
-
-        total_views_products += get_product_by_id(product_id, db).views
+        total_views_products += get_product_by_id(product_id, db).number_views
     total_views_profile = user.views
     top_product_sale = max(sales, key=lambda k: sales[k])
 
@@ -77,6 +76,8 @@ async def statistics(db: Session = Depends(get_db), username: str = Depends(get_
                 if category["id"] not in quantity_per_category.keys():
                     quantity_per_category[category["id"]] = 0
                 quantity_per_category[category["id"]] += item["quantity"]
+
+
 
     max_product = get_product_by_id(max(quantity_per_product, key=lambda k: quantity_per_product[k]), db)
     max_category = get_category_by_id(max(quantity_per_category, key=lambda k: quantity_per_category[k]), db)

--- a/routers/statistics.py
+++ b/routers/statistics.py
@@ -55,6 +55,14 @@ async def statistics(db: Session = Depends(get_db), username: str = Depends(get_
     user = get_user(username, db)
     orders = get_orders_by_user_id(user.id, db)
 
+    if orders == []:
+        response = {
+            "max_product": None,
+            "max_category": None,
+            "max_productor": None
+        }
+        return JSONResponse(status_code=200, content=jsonable_encoder(response))
+
     quantity_per_product = {}
     quantity_per_category = {}
     quantity_per_productor = {}
@@ -73,15 +81,17 @@ async def statistics(db: Session = Depends(get_db), username: str = Depends(get_
             quantity_per_productor[item["product"]["user_id"]] += item["quantity"]
 
             for category in item["product"]["categories"]:
+                print(category)
                 if category["id"] not in quantity_per_category.keys():
                     quantity_per_category[category["id"]] = 0
                 quantity_per_category[category["id"]] += item["quantity"]
 
-
-
     max_product = get_product_by_id(max(quantity_per_product, key=lambda k: quantity_per_product[k]), db)
-    max_category = get_category_by_id(max(quantity_per_category, key=lambda k: quantity_per_category[k]), db)
     max_productor = get_user_by_id(max(quantity_per_productor, key=lambda k: quantity_per_productor[k]), db)
+    max_category = None
+
+    if quantity_per_category != {}:
+        max_category = get_category_by_id(max(quantity_per_category, key=lambda k: quantity_per_category[k]), db)
 
     response = {
         "max_product": max_product,

--- a/routers/statistics.py
+++ b/routers/statistics.py
@@ -20,10 +20,11 @@ async def statistics(db: Session = Depends(get_db), username: str = Depends(get_
     user = get_user(username, db)
     products_names = [product.name for product in get_products_by_user_id(user.id, db)]
     sales = {}
+    total_quantity = 0
     for product_id in products_names:
         sales[product_id] = 0
         items = get_orders_items_by_product_id(product_id, db)
         for item in items:
             sales[product_id] += item.quantity
-    return sales
-
+            total_quantity += item.quantity
+    return sales, total_quantity

--- a/routers/statistics.py
+++ b/routers/statistics.py
@@ -7,8 +7,10 @@ from auth.JWTBearer import JWTBearer
 from auth.auth import get_current_user, jwks
 from db.database import get_db
 from repositories.orderItemRepo import get_orders_items_by_product_id
-from repositories.productRepo import get_products_by_user_id
-from repositories.userRepo import get_user
+from repositories.orderRepo import get_orders_by_user_id 
+from repositories.productRepo import get_products_by_user_id, get_product_by_id
+from repositories.userRepo import get_user, get_user_by_id
+from repositories.categoryRepo import get_category_by_id
 
 auth = JWTBearer(jwks)
 router = APIRouter(tags=['Statistics'])
@@ -31,7 +33,7 @@ async def statistics(db: Session = Depends(get_db), username: str = Depends(get_
         for item in items:
             sales[product_id] += item.quantity
             total_quantity += item.quantity
-    response = {"grafico": sales, "total_quantity": total_quantity, "total_views_profile": total_views_profile,
+    response = {"chart": sales, "total_quantity": total_quantity, "total_views_profile": total_views_profile,
                 "total_views_products": total_views_products, "top_product": products_names[0]}
     return JSONResponse(status_code=200, content=jsonable_encoder(response))
 
@@ -41,8 +43,42 @@ async def statistics(db: Session = Depends(get_db), username: str = Depends(get_
     """
         Function that returns the statistics of the buyer
     """
-    pass
 
-# products por categorias
-# top my category
-# productores com mais vendas nessa categoria
+    user = get_user(username, db)
+    orders = get_orders_by_user_id(user.id, db)
+
+    quantity_per_product = {}
+    quantity_per_category = {}
+    quantity_per_productor = {}
+    
+    for order in orders:
+        order_items = order.get_order_items(db)
+        for item in order_items:
+
+            if item["product"]["id"] not in quantity_per_product.keys():
+                quantity_per_product[item["product"]["id"]] = 0
+            
+            if item["product"]["user_id"] not in quantity_per_productor.keys():
+                quantity_per_productor[item["product"]["user_id"]] = 0
+
+            quantity_per_product[item["product"]["id"]] += item["quantity"]
+            quantity_per_productor[item["product"]["user_id"]] += item["quantity"]
+
+            for category in item["product"]["categories"]:
+                if category["id"] not in quantity_per_category.keys():
+                    quantity_per_category[category["id"]] = 0
+                quantity_per_category[category["id"]] += item["quantity"]
+
+    max_product = get_product_by_id(max(quantity_per_product, key=lambda k: quantity_per_product[k]), db)   
+    max_category = get_category_by_id(max(quantity_per_category, key=lambda k: quantity_per_category[k]), db)
+    max_productor = get_user_by_id(max(quantity_per_productor, key=lambda k: quantity_per_productor[k]), db)
+
+    response = {
+        "max_product": max_product,
+        "max_category": max_category,
+        "max_productor": max_productor
+    }
+    
+    return JSONResponse(status_code = 200, content=jsonable_encoder(response))
+
+

--- a/routers/statistics.py
+++ b/routers/statistics.py
@@ -1,5 +1,7 @@
 from fastapi import APIRouter, Depends
+from fastapi.encoders import jsonable_encoder
 from sqlalchemy.orm import Session
+from starlette.responses import JSONResponse
 
 from auth.JWTBearer import JWTBearer
 from auth.auth import get_current_user, jwks
@@ -12,19 +14,35 @@ auth = JWTBearer(jwks)
 router = APIRouter(tags=['Statistics'])
 
 
-@router.get("/statistics")
+@router.get("/statistics/seller", dependencies=[Depends(auth)])
 async def statistics(db: Session = Depends(get_db), username: str = Depends(get_current_user)):
     """
-        Function that returns the statistics of the application
+        Function that returns the statistics of the seller
     """
     user = get_user(username, db)
     products_names = [product.name for product in get_products_by_user_id(user.id, db)]
     sales = {}
     total_quantity = 0
+    total_views_profile = 0
+    total_views_products = 0
     for product_id in products_names:
         sales[product_id] = 0
         items = get_orders_items_by_product_id(product_id, db)
         for item in items:
             sales[product_id] += item.quantity
             total_quantity += item.quantity
-    return sales, total_quantity
+    response = {"grafico": sales, "total_quantity": total_quantity, "total_views_profile": total_views_profile,
+                "total_views_products": total_views_products, "top_product": products_names[0]}
+    return JSONResponse(status_code=200, content=jsonable_encoder(response))
+
+
+@router.get("/statistics/buyer", dependencies=[Depends(auth)])
+async def statistics(db: Session = Depends(get_db), username: str = Depends(get_current_user)):
+    """
+        Function that returns the statistics of the buyer
+    """
+    pass
+
+# products por categorias
+# top my category
+# productores com mais vendas nessa categoria

--- a/routers/statistics.py
+++ b/routers/statistics.py
@@ -7,7 +7,7 @@ from auth.JWTBearer import JWTBearer
 from auth.auth import get_current_user, jwks
 from db.database import get_db
 from repositories.orderItemRepo import get_orders_items_by_product_id
-from repositories.orderRepo import get_orders_by_user_id 
+from repositories.orderRepo import get_orders_by_user_id
 from repositories.productRepo import get_products_by_user_id, get_product_by_id
 from repositories.userRepo import get_user, get_user_by_id
 from repositories.categoryRepo import get_category_by_id
@@ -25,7 +25,6 @@ async def statistics(db: Session = Depends(get_db), username: str = Depends(get_
     products_names = [product.name for product in get_products_by_user_id(user.id, db)]
     sales = {}
     total_quantity = 0
-    total_views_profile = 0
     total_views_products = 0
     for product_id in products_names:
         sales[product_id] = 0
@@ -33,8 +32,18 @@ async def statistics(db: Session = Depends(get_db), username: str = Depends(get_
         for item in items:
             sales[product_id] += item.quantity
             total_quantity += item.quantity
-    response = {"chart": sales, "total_quantity": total_quantity, "total_views_profile": total_views_profile,
-                "total_views_products": total_views_products, "top_product": products_names[0]}
+
+        total_views_products += get_product_by_id(product_id, db).views
+    total_views_profile = 0  # TODO: IMPLEMENTAR
+    top_product_sale = max(sales, key=lambda k: sales[k])
+
+    response = {"chart": sales,
+                "statistics":
+                    {
+                        "total quantity": total_quantity, "total views profile": total_views_profile,
+                        "total views Products": total_views_products, "top product sale": products_names[0]
+                    }
+                }
     return JSONResponse(status_code=200, content=jsonable_encoder(response))
 
 
@@ -50,14 +59,14 @@ async def statistics(db: Session = Depends(get_db), username: str = Depends(get_
     quantity_per_product = {}
     quantity_per_category = {}
     quantity_per_productor = {}
-    
+
     for order in orders:
         order_items = order.get_order_items(db)
         for item in order_items:
 
             if item["product"]["id"] not in quantity_per_product.keys():
                 quantity_per_product[item["product"]["id"]] = 0
-            
+
             if item["product"]["user_id"] not in quantity_per_productor.keys():
                 quantity_per_productor[item["product"]["user_id"]] = 0
 
@@ -69,7 +78,7 @@ async def statistics(db: Session = Depends(get_db), username: str = Depends(get_
                     quantity_per_category[category["id"]] = 0
                 quantity_per_category[category["id"]] += item["quantity"]
 
-    max_product = get_product_by_id(max(quantity_per_product, key=lambda k: quantity_per_product[k]), db)   
+    max_product = get_product_by_id(max(quantity_per_product, key=lambda k: quantity_per_product[k]), db)
     max_category = get_category_by_id(max(quantity_per_category, key=lambda k: quantity_per_category[k]), db)
     max_productor = get_user_by_id(max(quantity_per_productor, key=lambda k: quantity_per_productor[k]), db)
 
@@ -78,7 +87,5 @@ async def statistics(db: Session = Depends(get_db), username: str = Depends(get_
         "max_category": max_category,
         "max_productor": max_productor
     }
-    
-    return JSONResponse(status_code = 200, content=jsonable_encoder(response))
 
-
+    return JSONResponse(status_code=200, content=jsonable_encoder(response))

--- a/routers/statistics.py
+++ b/routers/statistics.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from auth.JWTBearer import JWTBearer
+from auth.auth import get_current_user, jwks
+from db.database import get_db
+from repositories.orderItemRepo import get_orders_items_by_product_id
+from repositories.productRepo import get_products_by_user_id
+from repositories.userRepo import get_user
+
+auth = JWTBearer(jwks)
+router = APIRouter(tags=['Statistics'])
+
+
+@router.get("/statistics")
+async def statistics(db: Session = Depends(get_db), username: str = Depends(get_current_user)):
+    """
+        Function that returns the statistics of the application
+    """
+    user = get_user(username, db)
+    products_names = [product.name for product in get_products_by_user_id(user.id, db)]
+    sales = {}
+    for product_id in products_names:
+        sales[product_id] = 0
+        items = get_orders_items_by_product_id(product_id, db)
+        for item in items:
+            sales[product_id] += item.quantity
+    return sales
+

--- a/routers/user.py
+++ b/routers/user.py
@@ -94,8 +94,8 @@ async def get_user_by_id(user_id: str, db: Session = Depends(get_db)):
     user = user_by_id(user_id, db)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
-    user.add_view(db)
     response = user.information()
+    user.add_views(db=db)
     response["products"] = [product.to_dict() for product in get_products_by_user_id(user_id=response['id'], db=db)]
     return JSONResponse(status_code=200, content=jsonable_encoder(response))
 

--- a/routers/user.py
+++ b/routers/user.py
@@ -94,6 +94,7 @@ async def get_user_by_id(user_id: str, db: Session = Depends(get_db)):
     user = user_by_id(user_id, db)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
+    user.add_view(db)
     response = user.information()
     response["products"] = [product.to_dict() for product in get_products_by_user_id(user_id=response['id'], db=db)]
     return JSONResponse(status_code=200, content=jsonable_encoder(response))

--- a/tests/routers/test_order_IT.py
+++ b/tests/routers/test_order_IT.py
@@ -82,6 +82,33 @@ def test_create_order_success():
     assert len(data["order_items"]) == 2
 
 
+def test_create_order_no_quantity():
+
+    os.environ['COGNITO_USER_CLIENT_ID'] = get_client_id()
+    response = client.post("/auth/sign-in", json={
+        "identifier": "brums21",
+        "password": os.getenv("PASSWORD_CORRECT")
+    })
+
+    assert response.status_code == 200
+    token = response.json()["token"]
+
+    order_items = [
+        {"product_id": "06e0da01-57fd-2228-95be-0d25c764ea55", "quantity": 2},
+        {"product_id": "06e0da01-57fd-2228-95be-0d25c764ea54", "quantity": 0},
+    ]
+
+    response = client.post(
+        ORDER,
+        headers={"Authorization": f"Bearer {token}"},
+        json=order_items
+    )
+
+    data = response.json()
+    assert response.status_code == 400, response.text
+    assert data["detail"] == "Quantity must be greater than 0."
+
+
 def test_create_order_no_product_found():
     os.environ['COGNITO_USER_CLIENT_ID'] = get_client_id()
     response = client.post("/auth/sign-in", json={

--- a/tests/routers/test_order_IT.py
+++ b/tests/routers/test_order_IT.py
@@ -52,15 +52,27 @@ def load_data():
     db.commit()
     db.close()
 
-
-def test_create_order_success():
-    os.environ['COGNITO_USER_CLIENT_ID'] = get_client_id()
+def login_user_1():
+    os.environ['COGNITO_USER_CLIENT_ID'] = os.getenv("COGNITO_USER_CLIENT_ID")
     response = client.post("/auth/sign-in", json={
         "identifier": "brums21",
         "password": os.getenv("PASSWORD_CORRECT")
     })
     assert response.status_code == 200
     token = response.json()["token"]
+    return token
+
+def login_user_2():
+    os.environ['COGNITO_USER_CLIENT_ID'] = os.getenv("COGNITO_USER_CLIENT_ID")
+    response = client.post("/auth/sign-in", json={
+        "identifier": "mariana",
+        "password": os.getenv("PASSWORD_CORRECT")
+    })
+    assert response.status_code == 200
+    token = response.json()["token"]
+    return token
+
+def test_create_order_success():
 
     order_items = [
         {"product_id": "06e0da01-57fd-2228-95be-0d25c764ea55", "quantity": 2},
@@ -69,7 +81,7 @@ def test_create_order_success():
 
     response = client.post(
         ORDER,
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {login_user_1()}"},
         json=order_items
     )
 
@@ -83,16 +95,6 @@ def test_create_order_success():
 
 
 def test_create_order_no_quantity():
-
-    os.environ['COGNITO_USER_CLIENT_ID'] = get_client_id()
-    response = client.post("/auth/sign-in", json={
-        "identifier": "brums21",
-        "password": os.getenv("PASSWORD_CORRECT")
-    })
-
-    assert response.status_code == 200
-    token = response.json()["token"]
-
     order_items = [
         {"product_id": "06e0da01-57fd-2228-95be-0d25c764ea55", "quantity": 2},
         {"product_id": "06e0da01-57fd-2228-95be-0d25c764ea54", "quantity": 0},
@@ -100,7 +102,7 @@ def test_create_order_no_quantity():
 
     response = client.post(
         ORDER,
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {login_user_1()}"},
         json=order_items
     )
 
@@ -110,13 +112,6 @@ def test_create_order_no_quantity():
 
 
 def test_create_order_no_product_found():
-    os.environ['COGNITO_USER_CLIENT_ID'] = get_client_id()
-    response = client.post("/auth/sign-in", json={
-        "identifier": "brums21",
-        "password": os.getenv("PASSWORD_CORRECT")
-    })
-    assert response.status_code == 200
-    token = response.json()["token"]
 
     order_items = [
         {"product_id": "06e0da01-57fd-2228-95be-0d25c764ea60", "quantity": 2},
@@ -125,7 +120,7 @@ def test_create_order_no_product_found():
 
     response = client.post(
         ORDER,
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {login_user_1()}"},
         json=order_items
     )
 
@@ -135,13 +130,6 @@ def test_create_order_no_product_found():
 
 
 def test_create_order_product_owner():
-    os.environ['COGNITO_USER_CLIENT_ID'] = get_client_id()
-    response = client.post("/auth/sign-in", json={
-        "identifier": "brums21",
-        "password": os.getenv("PASSWORD_CORRECT")
-    })
-    assert response.status_code == 200
-    token = response.json()["token"]
 
     order_items = [
         {"product_id": "06e0da01-57fd-2227-95be-0d25c764ea56", "quantity": 2},
@@ -150,7 +138,7 @@ def test_create_order_product_owner():
 
     response = client.post(
         ORDER,
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {login_user_1()}"},
         json=order_items
     )
 
@@ -160,13 +148,6 @@ def test_create_order_product_owner():
 
 
 def test_create_order_quantity_zero():
-    os.environ['COGNITO_USER_CLIENT_ID'] = get_client_id()
-    response = client.post("/auth/sign-in", json={
-        "identifier": "mariana",
-        "password": os.getenv("PASSWORD_CORRECT")
-    })
-    assert response.status_code == 200
-    token = response.json()["token"]
 
     order_items = [
         {"product_id": "06e0da01-57fd-2227-95be-0d25c764ea56", "quantity": 0},
@@ -175,7 +156,7 @@ def test_create_order_quantity_zero():
 
     response = client.post(
         ORDER,
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {login_user_1()}"},
         json=order_items
     )
 
@@ -185,13 +166,8 @@ def test_create_order_quantity_zero():
 
 
 def test_get_order():
-    os.environ['COGNITO_USER_CLIENT_ID'] = get_client_id()
-    response = client.post("/auth/sign-in", json={
-        "identifier": "brums21",
-        "password": os.getenv("PASSWORD_CORRECT")
-    })
-    assert response.status_code == 200
-    token = response.json()["token"]
+
+    token = login_user_1()
 
     response = client.get(
         ORDER + "?status=Accepted&sort=desc_date",
@@ -232,17 +208,10 @@ def test_get_order():
 
 
 def test_get_order_invalid_sort():
-    os.environ['COGNITO_USER_CLIENT_ID'] = get_client_id()
-    response = client.post("/auth/sign-in", json={
-        "identifier": "brums21",
-        "password": os.getenv("PASSWORD_CORRECT")
-    })
-    assert response.status_code == 200
-    token = response.json()["token"]
 
     response = client.get(
         ORDER + "?status=Accepted&sort=invalid_sort",
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {login_user_1()}"},
     )
 
     data = response.json()
@@ -251,18 +220,10 @@ def test_get_order_invalid_sort():
 
 
 def test_get_order_invalid_status():
-    os.environ['COGNITO_USER_CLIENT_ID'] = get_client_id()
-    response = client.post("/auth/sign-in", json={
-        "identifier": "brums21",
-        "password": os.getenv("PASSWORD_CORRECT")
-    })
-    assert response.status_code == 200
-    token = response.json()["token"]
 
-    # TODO: mudar isto
     response = client.get(
         ORDER + "?status=InvalidStatus&sort=desc_price",
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {login_user_1()}"},
     )
 
     data = response.json()
@@ -271,17 +232,10 @@ def test_get_order_invalid_status():
 
 
 def test_get_order_seller():
-    os.environ['COGNITO_USER_CLIENT_ID'] = get_client_id()
-    response = client.post("/auth/sign-in", json={
-        "identifier": "mariana",
-        "password": os.getenv("PASSWORD_CORRECT")
-    })
-    assert response.status_code == 200
-    token = response.json()["token"]
 
     response = client.get(
         ORDER + "/seller",
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {login_user_1()}"},
     )
 
     data = response.json()
@@ -289,13 +243,6 @@ def test_get_order_seller():
 
 
 def test_get_order_by_id_success():
-    os.environ['COGNITO_USER_CLIENT_ID'] = get_client_id()
-    response = client.post("/auth/sign-in", json={
-        "identifier": "brums21",
-        "password": os.getenv("PASSWORD_CORRECT")
-    })
-    assert response.status_code == 200
-    token = response.json()["token"]
 
     order_items = [
         {"product_id": "06e0da01-57fd-2228-95be-0d25c764ea55", "quantity": 2},
@@ -304,7 +251,7 @@ def test_get_order_by_id_success():
 
     response = client.post(
         ORDER,
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {login_user_1()}"},
         json=order_items
     )
 
@@ -314,7 +261,7 @@ def test_get_order_by_id_success():
 
     response = client.get(
         ORDER + "/" + id,
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {login_user_2()}"},
     )
 
     data = response.json()
@@ -322,17 +269,10 @@ def test_get_order_by_id_success():
 
 
 def test_order_by_id_order_not_found():
-    os.environ['COGNITO_USER_CLIENT_ID'] = get_client_id()
-    response = client.post("/auth/sign-in", json={
-        "identifier": "brums21",
-        "password": os.getenv("PASSWORD_CORRECT")
-    })
-    assert response.status_code == 200
-    token = response.json()["token"]
 
     response = client.get(
         ORDER + "/someorderid",
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {login_user_1()}"},
     )
 
     data = response.json()
@@ -341,13 +281,6 @@ def test_order_by_id_order_not_found():
 
 
 def test_order_by_id_order_no_permission():
-    os.environ['COGNITO_USER_CLIENT_ID'] = get_client_id()
-    response = client.post("/auth/sign-in", json={
-        "identifier": "brums21",
-        "password": os.getenv("PASSWORD_CORRECT")
-    })
-    assert response.status_code == 200
-    token = response.json()["token"]
 
     order_items = [
         {"product_id": "06e0da01-57fd-2228-95be-0d25c764ea55", "quantity": 2},
@@ -356,7 +289,7 @@ def test_order_by_id_order_no_permission():
 
     response = client.post(
         ORDER,
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {login_user_1()}"},
         json=order_items
     )
 
@@ -364,17 +297,9 @@ def test_order_by_id_order_no_permission():
     assert response.status_code == 201, response.text
     id = data["id"]
 
-    os.environ['COGNITO_USER_CLIENT_ID'] = get_client_id()
-    response = client.post("/auth/sign-in", json={
-        "identifier": "mariana",
-        "password": os.getenv("PASSWORD_CORRECT")
-    })
-    assert response.status_code == 200
-    token = response.json()["token"]
-
     response = client.get(
         ORDER + "/" + id,
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {login_user_2()}"},
     )
 
     data = response.json()

--- a/tests/routers/test_order_IT.py
+++ b/tests/routers/test_order_IT.py
@@ -53,27 +53,28 @@ def load_data():
     db.close()
 
 def login_user_1():
-    os.environ['COGNITO_USER_CLIENT_ID'] = os.getenv("COGNITO_USER_CLIENT_ID")
+    os.environ['COGNITO_USER_CLIENT_ID'] = get_client_id()
     response = client.post("/auth/sign-in", json={
         "identifier": "brums21",
         "password": os.getenv("PASSWORD_CORRECT")
     })
     assert response.status_code == 200
     token = response.json()["token"]
+
     return token
 
 def login_user_2():
-    os.environ['COGNITO_USER_CLIENT_ID'] = os.getenv("COGNITO_USER_CLIENT_ID")
+    os.environ['COGNITO_USER_CLIENT_ID'] = get_client_id()
     response = client.post("/auth/sign-in", json={
         "identifier": "mariana",
         "password": os.getenv("PASSWORD_CORRECT")
     })
     assert response.status_code == 200
     token = response.json()["token"]
+
     return token
 
 def test_create_order_success():
-
     order_items = [
         {"product_id": "06e0da01-57fd-2228-95be-0d25c764ea55", "quantity": 2},
         {"product_id": "06e0da01-57fd-2228-95be-0d25c764ea54", "quantity": 1},
@@ -95,6 +96,7 @@ def test_create_order_success():
 
 
 def test_create_order_no_quantity():
+
     order_items = [
         {"product_id": "06e0da01-57fd-2228-95be-0d25c764ea55", "quantity": 2},
         {"product_id": "06e0da01-57fd-2228-95be-0d25c764ea54", "quantity": 0},
@@ -156,7 +158,7 @@ def test_create_order_quantity_zero():
 
     response = client.post(
         ORDER,
-        headers={"Authorization": f"Bearer {login_user_1()}"},
+        headers={"Authorization": f"Bearer {login_user_2()}"},
         json=order_items
     )
 
@@ -167,43 +169,42 @@ def test_create_order_quantity_zero():
 
 def test_get_order():
 
-    token = login_user_1()
-
     response = client.get(
         ORDER + "?status=Accepted&sort=desc_date",
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {login_user_2()}"},
     )
 
     assert response.status_code == 200, response.text
 
     response = client.get(
         ORDER + "?status=Accepted&sort=asc_date",
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {login_user_2()}"},
     )
     assert response.status_code == 200, response.text
 
     response = client.get(
         ORDER + "?status=Accepted&sort=desc_price",
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {login_user_2()}"},
     )
     assert response.status_code == 200, response.text
 
     response = client.get(
         ORDER + "?status=Accepted&sort=asc_price",
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {login_user_2()}"},
     )
     assert response.status_code == 200, response.text
 
     response = client.get(
         ORDER + "?status=Accepted&sort=desc_quantity",
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {login_user_2()}"},
     )
     assert response.status_code == 200, response.text
 
     response = client.get(
         ORDER + "?status=Accepted&sort=asc_quantity",
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {login_user_2()}"},
     )
+
     assert response.status_code == 200, response.text
 
 
@@ -235,7 +236,7 @@ def test_get_order_seller():
 
     response = client.get(
         ORDER + "/seller",
-        headers={"Authorization": f"Bearer {login_user_1()}"},
+        headers={"Authorization": f"Bearer {login_user_2()}"},
     )
 
     data = response.json()
@@ -261,7 +262,7 @@ def test_get_order_by_id_success():
 
     response = client.get(
         ORDER + "/" + id,
-        headers={"Authorization": f"Bearer {login_user_2()}"},
+        headers={"Authorization": f"Bearer {login_user_1()}"},
     )
 
     data = response.json()

--- a/tests/routers/test_statistics.py
+++ b/tests/routers/test_statistics.py
@@ -58,19 +58,31 @@ def load_data():
     db.commit()
     db.close()
 
+def login_user_1():
+    os.environ['COGNITO_USER_CLIENT_ID'] = os.getenv("COGNITO_USER_CLIENT_ID")
+    response = client.post("/auth/sign-in", json={
+        "identifier": "brums21",
+        "password": os.getenv("PASSWORD_CORRECT")
+    })
+    assert response.status_code == 200
+    token = response.json()["token"]
+    return token
 
-def test_get_statistics_seller():
-    os.environ['COGNITO_USER_CLIENT_ID'] = get_client_id()
+def login_user_2():
+    os.environ['COGNITO_USER_CLIENT_ID'] = os.getenv("COGNITO_USER_CLIENT_ID")
     response = client.post("/auth/sign-in", json={
         "identifier": "mariana",
         "password": os.getenv("PASSWORD_CORRECT")
     })
     assert response.status_code == 200
     token = response.json()["token"]
+    return token
 
+
+def test_get_statistics_seller():
     response = client.get(
         SELLER_STATISTICS,
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {login_user_1()}"},
     )
 
     assert response.status_code == 200, response.text
@@ -78,36 +90,19 @@ def test_get_statistics_seller():
 
 def test_get_statistics_buyer_no_orders():
 
-    os.environ['COGNITO_USER_CLIENT_ID'] = get_client_id()
-    response = client.post("/auth/sign-in", json={
-        "identifier": "brums21",
-        "password": os.getenv("PASSWORD_CORRECT")
-    })
-    assert response.status_code == 200
-    token = response.json()["token"]
-
     response = client.get(
         BUYER_STATISTICS,
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {login_user_1()}"},
     )
 
     data = response.json()
     assert response.status_code == 200, response.text
-    assert data["max_product"] == None
-    assert data["max_category"] == None
-    assert data["max_productor"] == None
+    assert data["statistics"]["max_product"] == None
+    assert data["statistics"]["max_category"] == None
+    assert data["statistics"]["max_productor"] == None
 
 
 def test_get_statistics_buyer_no_category():
-
-    os.environ['COGNITO_USER_CLIENT_ID'] = get_client_id()
-    response = client.post("/auth/sign-in", json={
-        "identifier": "brums21",
-        "password": os.getenv("PASSWORD_CORRECT")
-    })
-
-    assert response.status_code == 200
-    token = response.json()["token"]
 
     order_items = [
         {"product_id": "06e0da01-57fd-2228-95be-0d25c764ea55", "quantity": 2},
@@ -116,34 +111,25 @@ def test_get_statistics_buyer_no_category():
 
     response = client.post(
         "/order",
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {login_user_1()}"},
         json=order_items
     )
 
-    data = response.json()
     assert response.status_code == 201, response.text
 
     response = client.get(
         BUYER_STATISTICS,
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {login_user_1()}"},
     )
 
     data = response.json()
     assert response.status_code == 200, response.text
-    assert data["max_product"] != None
-    assert data["max_category"] == None
-    assert data["max_productor"] != None
+    assert data["statistics"]["max_product"] != None
+    assert data["statistics"]["max_category"] == None
+    assert data["statistics"]["max_productor"] != None
+
 
 def test_get_statistics_buyer_accepted():
-
-    os.environ['COGNITO_USER_CLIENT_ID'] = get_client_id()
-    response = client.post("/auth/sign-in", json={
-        "identifier": "brums21",
-        "password": os.getenv("PASSWORD_CORRECT")
-    })
-
-    assert response.status_code == 200
-    token = response.json()["token"]
 
     order_items = [
         {"product_id": "06e0da01-57fd-2228-95be-0d25c764ea58", "quantity": 2},
@@ -152,7 +138,7 @@ def test_get_statistics_buyer_accepted():
 
     response = client.post(
         "/order",
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {login_user_1()}"},
         json=order_items
     )
 
@@ -160,11 +146,11 @@ def test_get_statistics_buyer_accepted():
 
     response = client.get(
         BUYER_STATISTICS,
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"Authorization": f"Bearer {login_user_1()}"},
     )
     
     data = response.json()
     assert response.status_code == 200, response.text
-    assert data["max_product"] != None
-    assert data["max_category"] != None
-    assert data["max_productor"] != None
+    assert data["statistics"]["max_product"] != None
+    assert data["statistics"]["max_category"] != None
+    assert data["statistics"]["max_productor"] != None

--- a/tests/routers/test_statistics.py
+++ b/tests/routers/test_statistics.py
@@ -1,0 +1,90 @@
+import os
+from uuid import uuid4
+
+import pytest
+import math
+
+from fastapi.testclient import TestClient
+
+from main import app
+from models.category import Category
+from models.product import Product
+from models.user import User
+from models.orders.order import Order
+from tests.test_sql_app import TestingSessionLocal
+from dotenv import load_dotenv
+
+load_dotenv()
+COGNITO_USER_CLIENT_ID = os.getenv("COGNITO_USER_CLIENT_ID")
+
+client = TestClient(app)
+
+SELLER_STATISTICS = "/statistics/seller"
+BUYER_STATISTICS = "/statistics/buyer"
+
+
+def get_client_id():
+    return COGNITO_USER_CLIENT_ID
+
+
+@pytest.fixture(scope="module", autouse=True)
+def load_data():
+    db = TestingSessionLocal()
+    db.query(Category).delete()
+    db.query(Product).delete()
+    db.query(User).delete()
+    user1 = User(id=str(uuid4()), name="Bruna", username="brums21", email="brums21.10@gmail.com", city="pombal",
+                 region="nao existe", photo="", role="Premium")
+    user2 = User(id=str(uuid4()), name="Mariana", username="mariana", email="marianaandrade@ua.pt", city="aveiro",
+                 region="nao sei", photo="", role="Premium")
+    db.add(user1)
+    db.add(user2)
+    db.add(Category(id="06e0da01-57fd-4441-95be-0d25c764ea57", name="Category1x", icon="icon1", slug="category1x"))
+    db.add(Product(id="06e0da01-57fd-2227-95be-0d25c764ea56", name="random product 1", description="some description 1",
+                   price=12.0, stockable=False, user_id=user1.id))
+    db.add(Product(id="06e0da01-57fd-2228-95be-0d25c764ea55", name="random product 2", description="some description 2",
+                   price=11.0, stockable=True, user_id=user2.id))
+    db.add(Product(id="06e0da01-57fd-2228-95be-0d25c764ea54", name="random product 3", description="some description 3",
+                   price=11.0, stockable=True, user_id=user2.id))
+    db.add(Product(id="06e0da01-57fd-2229-95be-123455555566", name="random product 4", description="some description 4",
+                   price=10.0, stockable=True, user_id="123456789023456789"))
+
+    db.commit()
+    db.close()
+
+def test_get_statistics_seller():
+
+    os.environ['COGNITO_USER_CLIENT_ID'] = get_client_id()
+    response = client.post("/auth/sign-in", json={
+        "identifier": "brums21",
+        "password": os.getenv("PASSWORD_CORRECT")
+    })
+    assert response.status_code == 200
+    token = response.json()["token"]
+
+    order_items = [
+        {"product_id": "06e0da01-57fd-2228-95be-0d25c764ea55", "quantity": 2},
+        {"product_id": "06e0da01-57fd-2228-95be-0d25c764ea54", "quantity": 1},
+    ]
+
+    response = client.post(
+        "/order",
+        headers={"Authorization": f"Bearer {token}"},
+        json=order_items
+    )
+
+    os.environ['COGNITO_USER_CLIENT_ID'] = get_client_id()
+    response = client.post("/auth/sign-in", json={
+        "identifier": "mariana",
+        "password": os.getenv("PASSWORD_CORRECT")
+    })
+    assert response.status_code == 200
+    token = response.json()["token"]
+
+    response = client.get(
+        SELLER_STATISTICS,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200, response.text
+

--- a/tests/routers/test_statistics.py
+++ b/tests/routers/test_statistics.py
@@ -68,6 +68,7 @@ def login_user_1():
     token = response.json()["token"]
     return token
 
+
 def login_user_2():
     os.environ['COGNITO_USER_CLIENT_ID'] = os.getenv("COGNITO_USER_CLIENT_ID")
     response = client.post("/auth/sign-in", json={


### PR DESCRIPTION
# Description 
This pull request focuses on the implementation of statistics for premium users, that have a dedicated page with some useful statistics, either as a buyer or as a seller. The following changes have been implemented:
1. **Added statistics as a buyer**: The premium client is able to view its main statistics based on the previously made orders. These statistics include data about their most bought product, their most bought category and the seller they buy the most from.
2. **Added statistics as a seller**: The premium client is able to view its sold products statistics, such as the amount of each product they've sold, total number of products sold, total profile views, total products' views, and their top product sale.

## Tasks Done
- [x] Implemented endpoint `/statistics/seller`, which returns the specified statistics mentioned above for premium seller clients.
- [x] Implemented endpoint `/statistics/buyer` which returns the specified statistics mentioned above for premium buyer clients. In case no order is placed, all responses are defaulted to `None`, and, in case they have bought products, but none have any category, only the top category is defaulted to `None`.

# Testing

Manual testing has been conducted to verify the functionality of the implemented changes in a real-user environment.

# Review Checklist

- [x] Tests covering the new features have been added or updated.
- [x] All tests have passed successfully.
- [x] Documentation has been updated as necessary to reflect the changes made.